### PR TITLE
fix: modify constructor to create hardened children with identitykeychain

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/AuthenticationKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/AuthenticationKeyChain.java
@@ -213,6 +213,7 @@ public class AuthenticationKeyChain extends ExternalKeyChain {
     protected AuthenticationKeyChain(KeyCrypter crypter, KeyParameter aesKey, AuthenticationKeyChain chain) {
         super(crypter, aesKey, chain);
         this.type = chain.type;
+        this.hardenedChildren = chain.hardenedChildren;
     }
 
     public static Builder<?> authenticationBuilder() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
blockchain identity keys were not created as hardened key once they keychain was encrypted.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone