### PR TITLE
fix: handle activation of Core 19/Basic Scheme

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -808,8 +808,9 @@ public abstract class NetworkParameters {
     }
 
     public void setDIP0024Active(int height) {
-        System.out.println("DIP24 is now active");
-        DIP0024BlockHeight = height;
+        if (DIP0024BlockHeight == Integer.MAX_VALUE) {
+            DIP0024BlockHeight = height;
+        }
     }
 
     public boolean isV19Active(StoredBlock block) {
@@ -821,8 +822,9 @@ public abstract class NetworkParameters {
     }
 
     public void setV19Active(int height) {
-        System.out.println("v19 is now active");
-        v19BlockHeight = height;
+        if (v19BlockHeight == Integer.MAX_VALUE) {
+            v19BlockHeight = height;
+        }
     }
 
     @Deprecated

--- a/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BLSLazyPublicKey.java
@@ -79,6 +79,21 @@ public class BLSLazyPublicKey extends BLSAbstractLazyObject {
         }
     }
 
+    public void bitcoinSerialize(OutputStream stream, boolean legacy) throws IOException {
+        if (!initialized && buffer == null) {
+            throw new IOException("public key and buffer are not initialized");
+        }
+        if (buffer == null) {
+            stream.write(publicKey.getBuffer(BLSPublicKey.BLS_CURVE_PUBKEY_SIZE, legacy));
+        } else {
+            if (this.legacy == legacy) {
+                stream.write(buffer);
+            } else {
+                getPublicKey().bitcoinSerialize(stream, legacy);
+            }
+        }
+    }
+
     public static BLSPublicKey invalidSignature = new BLSPublicKey();
 
     public BLSPublicKey getPublicKey() {

--- a/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeList.java
+++ b/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeList.java
@@ -46,17 +46,28 @@ public class SimplifiedMasternodeList extends Message {
         super(params, payload, offset, protocolVersion);
     }
 
-    SimplifiedMasternodeList(SimplifiedMasternodeList other) {
+    SimplifiedMasternodeList(SimplifiedMasternodeList other, short version) {
         super(other.params);
+        this.version = version;
+        this.protocolVersion = version == SimplifiedMasternodeListDiff.BASIC_BLS_VERSION ?
+                NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion() :
+                NetworkParameters.ProtocolVersion.BLS_LEGACY.getBitcoinProtocolVersion();
         this.blockHash = other.blockHash;
         this.height = other.height;
         mnMap = new HashMap<Sha256Hash, SimplifiedMasternodeListEntry>(other.mnMap);
+        // tell all entries to render as version 2 (BLS basic scheme)
+        for (SimplifiedMasternodeListEntry mn : mnMap.values()) {
+            mn.version = version;
+        }
         mnUniquePropertyMap = new HashMap<Sha256Hash, Pair<Sha256Hash, Integer>>(other.mnUniquePropertyMap);
         this.storedBlock = other.storedBlock;
     }
 
-    SimplifiedMasternodeList(NetworkParameters params, ArrayList<SimplifiedMasternodeListEntry> entries) {
+    SimplifiedMasternodeList(NetworkParameters params, ArrayList<SimplifiedMasternodeListEntry> entries, int protocolVersion) {
         super(params);
+        this.protocolVersion = protocolVersion;
+        this.version = protocolVersion == NetworkParameters.ProtocolVersion.BLS_LEGACY.getBitcoinProtocolVersion() ?
+                SimplifiedMasternodeListDiff.LEGACY_BLS_VERSION : SimplifiedMasternodeListDiff.BASIC_BLS_VERSION;
         this.blockHash = params.getGenesisBlock().getHash();
         this.height = -1;
         mnUniquePropertyMap = new HashMap<Sha256Hash, Pair<Sha256Hash, Integer>>();
@@ -109,7 +120,9 @@ public class SimplifiedMasternodeList extends Message {
 
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
-        Utils.uint16ToByteStreamLE(version, stream);
+        if (protocolVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.BLS_SCHEME)) {
+            Utils.uint16ToByteStreamLE(version, stream);
+        }
         stream.write(blockHash.getReversedBytes());
         Utils.uint32ToByteStreamLE(height, stream);
 
@@ -150,10 +163,11 @@ public class SimplifiedMasternodeList extends Message {
 
         lock.lock();
         try {
+            // this should not be necessary since the activation height is hard coded
             if (diff.getVersion() >= SimplifiedMasternodeListDiff.BASIC_BLS_VERSION) {
                 params.setBasicBLSSchemeActivationHeight((int)((CoinbaseTx)diff.coinBaseTx.getExtraPayloadObject()).height);
             }
-            SimplifiedMasternodeList result = new SimplifiedMasternodeList(this);
+            SimplifiedMasternodeList result = new SimplifiedMasternodeList(this, diff.getVersion());
 
             result.blockHash = diff.blockHash;
             result.height = cbtx.getHeight();

--- a/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntry.java
+++ b/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntry.java
@@ -119,7 +119,7 @@ public class SimplifiedMasternodeListEntry extends Masternode {
         stream.write(proRegTxHash.getReversedBytes());
         stream.write(confirmedHash.getReversedBytes());
         service.bitcoinSerialize(stream);
-        pubKeyOperator.bitcoinSerialize(stream);
+        pubKeyOperator.bitcoinSerialize(stream, version == LEGACY_BLS_VERSION);
         keyIdVoting.bitcoinSerialize(stream);
         stream.write(isValid ? 1 : 0);
         if (version == BASIC_BLS_VERSION) {

--- a/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListManager.java
+++ b/core/src/main/java/org/bitcoinj/evolution/SimplifiedMasternodeListManager.java
@@ -57,6 +57,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.bitcoinj.evolution.SimplifiedMasternodeListDiff.BASIC_BLS_VERSION;
+import static org.bitcoinj.evolution.SimplifiedMasternodeListDiff.LEGACY_BLS_VERSION;
 
 /**
  * This class manages the state of the masternode lists and quorums.  It does so with help from
@@ -313,8 +314,12 @@ public class SimplifiedMasternodeListManager extends AbstractManager implements 
             processQuorumList(quorumState.getQuorumListAtTip());
 
             unCache();
-            if (mnlistdiff.coinBaseTx.getExtraPayloadObject().getVersion() >= LLMQ_FORMAT_VERSION && quorumState.quorumList.size() > 0)
+            if (mnlistdiff.coinBaseTx.getExtraPayloadObject().getVersion() == LLMQ_FORMAT_VERSION && quorumState.quorumList.size() > 0)
                 setFormatVersion(LLMQ_FORMAT_VERSION);
+            if (mnlistdiff.getVersion() == LEGACY_BLS_VERSION)
+                setFormatVersion(QUORUM_ROTATION_FORMAT_VERSION);
+            else if (mnlistdiff.getVersion() == BASIC_BLS_VERSION)
+                setFormatVersion(BLS_SCHEME_FORMAT_VERSION);
             if (mnlistdiff.hasChanges() || quorumState.getPendingBlocks().size() < MAX_CACHE_SIZE || saveOptions == SaveOptions.SAVE_EVERY_BLOCK)
                 save();
 

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -319,6 +319,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
 
         DIP0008BlockHeight = 1088640;
         DIP0024BlockHeight = 1737792 + 4 * 288; // DIP24 activation time + 5 cycles
+        v19BlockHeight = 1874880;
 
         // long living quorum params
         addLLMQ(LLMQParameters.LLMQType.LLMQ_50_60);

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -123,6 +123,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
         DIP0008BlockHeight = 78800;
         DIP0024BlockHeight = 769700 + 4 * 288;
+        v19BlockHeight = 850100;
 
         //LLMQ parameters
         addLLMQ(LLMQParameters.LLMQType.LLMQ_50_60);

--- a/core/src/main/java/org/bitcoinj/quorums/SimplifiedQuorumList.java
+++ b/core/src/main/java/org/bitcoinj/quorums/SimplifiedQuorumList.java
@@ -178,7 +178,9 @@ public class SimplifiedQuorumList extends Message {
             //if quorum was created before DIP8 activation, then allow it to be added
             if (chainHeight >= params.getDIP0008BlockHeight() || !isLoadingBootstrap) {
                 //for some reason llmqType 2 quorumHashs are from block 72000, which is before DIP8 on testnet.
-                if (!params.getId().equals(NetworkParameters.ID_TESTNET) && !isFirstQuorumCheck && entry.llmqType != 2 && !params.getAssumeValidQuorums().contains(entry.quorumHash)) {
+                if (!params.getId().equals(NetworkParameters.ID_TESTNET) && !isFirstQuorumCheck &&
+                        (entry.llmqType != LLMQParameters.LLMQType.LLMQ_400_60.value && entry.llmqType != LLMQParameters.LLMQType.LLMQ_400_85.value) &&
+                        !params.getAssumeValidQuorums().contains(entry.quorumHash)) {
                     throw new ProtocolException("QuorumHash not found: " + entry.quorumHash);
                 }
             }

--- a/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntryTest.java
+++ b/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodeListEntryTest.java
@@ -20,23 +20,40 @@ import org.bitcoinj.core.Address;
 import org.bitcoinj.core.KeyId;
 import org.bitcoinj.core.MasternodeAddress;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.BLSLazyPublicKey;
-import org.bitcoinj.crypto.BLSScheme;
 import org.bitcoinj.params.UnitTestParams;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SimplifiedMasternodeListEntryTest {
     NetworkParameters UNITTEST = UnitTestParams.get();
 
     @Test
+    public void readBytesV1Test() {
+        byte[] smle = Utils.HEX.decode("318c32ec1598fa8f38dc76e28d15c00c20553c7020161a4c64742524a18465c39b2d789571a3b223a5365fbde69b3fe7143c4f9ebc6293afb84d340f0000000000000000000000000000ffff23a3e2204e1f08b4c1a8b9c1402ea84afe7c47f7e98d657df873b9747a0e4a497120ec62c81f314ad91a6f3384648e7e60f2734554f7f4c0fe75eec22907d6b043edb0df74ccc7b85a4500");
+        SimplifiedMasternodeListEntry entry = new SimplifiedMasternodeListEntry(UNITTEST, smle, 0, NetworkParameters.ProtocolVersion.BLS_LEGACY.getBitcoinProtocolVersion());
+        assertEquals(1, entry.version);
+        assertEquals(0, entry.type);
+        assertEquals("c36584a1242574644c1a1620703c55200cc0158de276dc388ffa9815ec328c31", entry.proRegTxHash.toString());
+        assertEquals("000000000f344db8af9362bc9e4f3c14e73f9be6bd5f36a523b2a37195782d9b", entry.confirmedHash.toString());
+        assertEquals(new MasternodeAddress("35.163.226.32", 19999), entry.service);
+        assertEquals("yidavU3B2BUNzaUv3gW6nmV4ojLNwPeazt", Address.fromPubKeyHash(UNITTEST, entry.keyIdVoting.getBytes()).toString());
+        assertEquals(new BLSLazyPublicKey(UNITTEST, Utils.HEX.decode("08b4c1a8b9c1402ea84afe7c47f7e98d657df873b9747a0e4a497120ec62c81f314ad91a6f3384648e7e60f2734554f7"), 0, false), entry.pubKeyOperator);
+        assertFalse(entry.isValid); // this masternode is not valid
+        assertEquals(Sha256Hash.wrap("a7fc065ab65f453c4b57c597467f4d126188d5807f08cfab6b1f6d52e30e067e"), entry.getHash());
+        entry.version = 2; // make sure serialization is with basic scheme
+        assertEquals(Sha256Hash.wrap("8a07d7243612fcbeb139b07673c20f63ae701d5508fe1ee8487d2edcb45d3da1"), entry.getHash());
+    }
+
+    @Test
     public void readBytesV2Test() {
         byte[] smle = Utils.HEX.decode("e7aef4f585df3def44b855219ae93d6e8cc49a8c96658c5cc0813c48f5384c33e2999069d702d61d852a74b1e07d6f58101e0352d84043e866ff7946bdf5987f00000000000000000000ffff7f0000012f3197fe8172fd3207d71125a053ff32266e11110c06c1184d5be0a8118d0131d6119b138ec4d0398e7eacc5e16a75f718ed796c3a4cab668936c1f6d0945a7b97d7c0fee7cf0101002caa114755a4648d422a5caa5c915597f8c733b8e146");
         SimplifiedMasternodeListEntry entry = new SimplifiedMasternodeListEntry(UNITTEST, smle, 0, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
-        BLSScheme.setLegacyDefault(entry.version == SimplifiedMasternodeListEntry.LEGACY_BLS_VERSION);
         assertEquals(2, entry.version);
         assertEquals(1, entry.type);
         assertEquals("334c38f5483c81c05c8c65968c9ac48c6e3de99a2155b844ef3ddf85f5f4aee7", entry.proRegTxHash.toString());

--- a/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodesTest.java
+++ b/core/src/test/java/org/bitcoinj/evolution/SimplifiedMasternodesTest.java
@@ -95,6 +95,7 @@ public class SimplifiedMasternodesTest {
             smle.pubKeyOperator = new BLSLazyPublicKey(sk.getPublicKey());
             smle.keyIdVoting = KeyId.fromBytes(Utils.HEX.decode(String.format("%040x", i)), false);
             smle.isValid = true;
+            smle.version = SimplifiedMasternodeListDiff.LEGACY_BLS_VERSION;
 
             entries.add(smle);
         }
@@ -124,7 +125,8 @@ public class SimplifiedMasternodesTest {
 
         assertArrayEquals(expectedHashes, calculatedHashes.toArray());
 
-        SimplifiedMasternodeList sml = new SimplifiedMasternodeList(PARAMS, entries);
+        SimplifiedMasternodeList sml = new SimplifiedMasternodeList(PARAMS, entries,
+                NetworkParameters.ProtocolVersion.BLS_LEGACY.getBitcoinProtocolVersion());
 
         String expectedMerkleRoot = "3b2a4f6be32c13070979910150d6be0ff1890f17b3169d1eabb96b217b6df2d7";
         String calculatedMerkleRoot = sml.calculateMerkleRoot().toString();


### PR DESCRIPTION
* allow BLSLazyPublicKey to serialize in different scheme
* applyDiff in SimplifiedMasternodeList will use scheme based on diff version
* serialize SimplifiedMasternodeListEntry according to version
* update SimplifiedMasternodesTest based on the above changes

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone