### PR TITLE
fix(coinjoin): account for 0 diff transactions when emitting events

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2420,9 +2420,9 @@ public class Wallet extends BaseTaggableObject
                 int diff = valueDifference.signum();
                 // We pick one callback based on the value difference, though a tx can of course both send and receive
                 // coins from the wallet.
-                if (diff > 0) {
+                if (diff >= 0) {
                     queueOnCoinsReceived(tx, prevBalance, newBalance);
-                } else if (diff < 0) {
+                } else {
                     queueOnCoinsSent(tx, prevBalance, newBalance);
                 }
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
CoinJoin transactions have a zero amount, preventing sent/received events from being emitted.


## What was done?
- Replace diff check with `diff >= 0` to emit the `coinsReceived` event.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction event notification logic to provide more comprehensive updates about wallet transactions.
	- Enhanced balance tracking to notify listeners for zero-sum and balance-changing transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->