### PR TITLE
fix(coinjoin): mixing limit

### DIFF
--- a/core/src/main/java/org/bitcoinj/coinjoin/utils/CoinJoinReporter.java
+++ b/core/src/main/java/org/bitcoinj/coinjoin/utils/CoinJoinReporter.java
@@ -221,6 +221,10 @@ public class CoinJoinReporter extends MixingProgressTracker {
                 PoolState state = sessionState.get(sessionId);
                 writer.write("Fee Charged on session: " + sessionId +  " state: " + state + " txid:" + tx.getTxId());
                 writer.newLine();
+            } else if (type == CoinJoinTransactionType.CombineDust) {
+                writeTime();
+                writer.write("Combining Dust: " + tx.getTxId());
+                writer.newLine();
             }
         } catch (IOException x) {
             throw new RuntimeException(x);

--- a/core/src/main/java/org/bitcoinj/coinjoin/utils/CoinJoinTransactionType.java
+++ b/core/src/main/java/org/bitcoinj/coinjoin/utils/CoinJoinTransactionType.java
@@ -54,14 +54,18 @@ public enum CoinJoinTransactionType {
                 if (CoinJoin.isCollateralAmount(firstOutput.getValue())) {
                     // <case3>, see CCoinJoinClientSession.makeCollateralAmounts
                     makeCollateral = true;
-                } else if (tx.getInputs().size() > 1 && tx.getValue(transactionBag).plus(tx.getFee()).equals(Coin.ZERO)) {
-                    // No good way to check if this is a dust output
-                    // except to check if the spending tx is a denomination
-                    Transaction spendingTx = firstOutput.getSpentBy() != null ? 
+                } else {
+                    Coin txFee = tx.getFee();
+
+                    if (txFee != null && tx.getInputs().size() > 1 && tx.getValue(transactionBag).plus(txFee).equals(Coin.ZERO)) {
+                        // No good way to check if this is a dust output
+                        // except to check if the spending tx is a denomination
+                        Transaction spendingTx = firstOutput.getSpentBy() != null ?
                                 firstOutput.getSpentBy().getParentTransaction() : null;
 
-                    if (spendingTx != null && isDenomination(spendingTx)) {
-                        return CombineDust;
+                        if (spendingTx != null && isDenomination(spendingTx)) {
+                            return CombineDust;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
CoinJoin limits denoms to 300, which prevents CoinJoin "dust" from being denominated.

## What was done?
- Automatically combine smaller outputs.
- Classify combining transaction.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced coin mixing functionality that consolidates smaller amounts into larger denominations when necessary.
  - Introduced a new transaction type for combining dust, with dedicated logging for related events, improving transaction tracking and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->