### PR TITLE
fix: avoid deadlock in CoinJoinExtension

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/CoinJoinExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinJoinExtension.java
@@ -442,6 +442,8 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
 
     public void refreshUnusedKeys() {
         List<IDeterministicKey> issuedKeys;
+        Set<Transaction> txes = wallet.getTransactions(true);
+        
         unusedKeysLock.lock();
         try {
             keyChainGroupLock.lock();
@@ -456,8 +458,6 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
                 unusedKeys.put(KeyId.fromBytes(key.getPubKeyHash()), (DeterministicKey) key);
                 keyUsage.put(key, false);
             });
-
-            Set<Transaction> txes = wallet.getTransactions(true);
 
             Stream<IDeterministicKey> usedKeys = issuedKeys.stream().filter(key -> {
                         boolean found = txes.stream().anyMatch(tx ->
@@ -491,6 +491,8 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
     public String getUnusedKeyReport() {
         List<IDeterministicKey> issuedKeys;
         HashMap<ImmutableList<ChildNumber>, IDeterministicKey> unusedKeyMap = Maps.newHashMap();
+        Set<Transaction> txes = wallet.getTransactions(true);
+        
         unusedKeysLock.lock();
         try {
             keyChainGroupLock.lock();
@@ -503,8 +505,6 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
             }
 
             issuedKeys.forEach(key -> unusedKeyMap.put(key.getPath(), key));
-
-            Set<Transaction> txes = wallet.getTransactions(true);
 
             Stream<IDeterministicKey> usedKeys = issuedKeys.stream().filter(key ->
                     txes.stream().anyMatch(tx ->
@@ -566,6 +566,8 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
     public String getKeyUsageReport() {
         List<IDeterministicKey> issuedKeys;
         HashMap<DeterministicKey, Integer> usedKeyMap = Maps.newHashMap();
+        Set<Transaction> txes = wallet.getTransactions(true);
+        
         unusedKeysLock.lock();
         try {
             keyChainGroupLock.lock();
@@ -576,8 +578,6 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
             } finally {
                 keyChainGroupLock.unlock();
             }
-
-            Set<Transaction> txes = wallet.getTransactions(true);
 
             issuedKeys.forEach(key -> txes.forEach(tx -> {
                 Stream<TransactionOutput> keyUsage = tx.getOutputs().stream().filter(output -> {
@@ -592,7 +592,6 @@ public class CoinJoinExtension extends AbstractKeyChainGroupExtension {
                     usedKeyMap.put((DeterministicKey) key, currentCount == null ? 1 : currentCount + 1);
                 }
             }));
-
 
             StringBuilder builder = new StringBuilder();
             builder.append("Duplicate Used Key List: \n");


### PR DESCRIPTION
## Issue being fixed or feature implemented
CoinJoinExtension goes into deadlock:

```
com.google.common.util.concurrent.CycleDetectingLockFactory$PotentialDeadlockException: wallet -> unusedKeysLock, unusedKeysLock -> wallet
at com.google.common.util.concurrent.CycleDetectingLockFactory$CycleDetectingReentrantLock.lock(CycleDetectingLockFactory.java:772)
at org.bitcoinj.wallet.CoinJoinExtension.getUnusedKeyReport(CoinJoinExtension.java:494)
```

## What was done?
The suggested solution is to `getTransactions` first outside of the lock.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal process for handling transaction data used in wallet key reporting, ensuring a more centralized and consistent approach. These adjustments maintain the current wallet functionalities while enhancing overall code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->