### PR TITLE
fix: shorten wallet toString output, unless with debug info

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/AbstractKeyChainGroupExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/AbstractKeyChainGroupExtension.java
@@ -527,7 +527,7 @@ abstract public class AbstractKeyChainGroupExtension implements KeyChainGroupExt
     }
 
     @Override
-    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey) {
+    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeDebugInfo) {
         return getWalletExtensionID() + ":\n" + (isInitialized() ? getKeyChainGroup().toString(includeLookahead, includePrivateKeys, aesKey) : "No keychains");
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupExtension.java
@@ -86,7 +86,7 @@ public interface KeyChainGroupExtension extends WalletExtension {
     void addEventListener(KeyChainEventListener listener);
     void addEventListener(KeyChainEventListener listener, Executor executor);
     boolean removeEventListener(KeyChainEventListener listener);
-    String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey);
+    String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeDebugInfo);
 
     boolean hasSpendableKeys();
     boolean isTransactionRevelant(Transaction tx);

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupExtension.java
@@ -86,6 +86,10 @@ public interface KeyChainGroupExtension extends WalletExtension {
     void addEventListener(KeyChainEventListener listener);
     void addEventListener(KeyChainEventListener listener, Executor executor);
     boolean removeEventListener(KeyChainEventListener listener);
+
+    default String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey) {
+        return toString(includeLookahead, includePrivateKeys, aesKey, false);
+    }
     String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeDebugInfo);
 
     boolean hasSpendableKeys();

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3698,25 +3698,25 @@ public class Wallet extends BaseTaggableObject
 
     @Override
     public String toString() {
-        return toString(false, false, null, true, true, null);
+        return toString(false, false, null, true, true, null, false);
     }
 
     /**
-     * @deprecated Use {@link #toString(boolean, boolean, KeyParameter, boolean, boolean, AbstractBlockChain)} instead.
+     * @deprecated Use {@link #toString(boolean, boolean, KeyParameter, boolean, boolean, AbstractBlockChain, boolean)} instead.
      */
     @Deprecated
     public String toString(boolean includePrivateKeys, boolean includeTransactions, boolean includeExtensions,
             @Nullable AbstractBlockChain chain) {
-        return toString(false, includePrivateKeys, null, includeTransactions, includeExtensions, chain);
+        return toString(false, includePrivateKeys, null, includeTransactions, includeExtensions, chain, false);
     }
 
     /**
-     * @deprecated Use {@link #toString(boolean, boolean, KeyParameter, boolean, boolean, AbstractBlockChain)} instead.
+     * @deprecated Use {@link #toString(boolean, boolean, KeyParameter, boolean, boolean, AbstractBlockChain, boolean)} instead.
      */
     @Deprecated
     public String toString(boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeTransactions,
-            boolean includeExtensions, @Nullable AbstractBlockChain chain) {
-        return toString(false, includePrivateKeys, aesKey, includeTransactions, includeExtensions, chain);
+            boolean includeExtensions, @Nullable AbstractBlockChain chain, boolean includeDebugInfo) {
+        return toString(false, includePrivateKeys, aesKey, includeTransactions, includeExtensions, chain, includeDebugInfo);
     }
 
     /**
@@ -3730,7 +3730,7 @@ public class Wallet extends BaseTaggableObject
      * @param chain If set, will be used to estimate lock times for block timelocked transactions.
      */
     public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey,
-            boolean includeTransactions, boolean includeExtensions, @Nullable AbstractBlockChain chain) {
+            boolean includeTransactions, boolean includeExtensions, @Nullable AbstractBlockChain chain, boolean includeDebugInfo) {
         lock.lock();
         keyChainGroupLock.lock();
         try {
@@ -3776,7 +3776,7 @@ public class Wallet extends BaseTaggableObject
             if (includeExtensions && keyChainExtensions.size() > 0) {
                 builder.append("\n>>> KEYCHAIN EXTENSIONS:\n");
                 for (KeyChainGroupExtension extension : keyChainExtensions.values()) {
-                    builder.append(extension.toString(includeLookahead, includePrivateKeys, aesKey)).append("\n\n");
+                    builder.append(extension.toString(includeLookahead, includePrivateKeys, aesKey, includeDebugInfo)).append("\n\n");
                 }
             }
             if (!watchedScripts.isEmpty()) {
@@ -3808,7 +3808,7 @@ public class Wallet extends BaseTaggableObject
             if (includeExtensions && extensions.size() > 0) {
                 builder.append("\n>>> EXTENSIONS:\n");
                 for (WalletExtension extension : extensions.values()) {
-                    builder.append(extension).append("\n\n");
+                    builder.append(extension.toString()).append("\n\n");
                 }
             }
             return builder.toString();

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3728,6 +3728,7 @@ public class Wallet extends BaseTaggableObject
      * @param includeTransactions Whether to print transaction data.
      * @param includeExtensions Whether to print extension data.
      * @param chain If set, will be used to estimate lock times for block timelocked transactions.
+     * @param includeDebugInfo If set, will include debug information
      */
     public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey,
             boolean includeTransactions, boolean includeExtensions, @Nullable AbstractBlockChain chain, boolean includeDebugInfo) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletEx.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletEx.java
@@ -1007,8 +1007,8 @@ public class WalletEx extends Wallet {
     }
 
     @Override
-    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeTransactions, boolean includeExtensions, @Nullable AbstractBlockChain chain) {
-        return super.toString(includeLookahead, includePrivateKeys, aesKey, includeTransactions, includeExtensions, chain) + getTransactionReport();
+    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeTransactions, boolean includeExtensions, @Nullable AbstractBlockChain chain, boolean includeDebugInfo) {
+        return super.toString(includeLookahead, includePrivateKeys, aesKey, includeTransactions, includeExtensions, chain, includeDebugInfo) + getTransactionReport();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/wallet/authentication/AuthenticationGroupExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/authentication/AuthenticationGroupExtension.java
@@ -537,9 +537,9 @@ public class AuthenticationGroupExtension extends AbstractKeyChainGroupExtension
     }
 
     @Override
-    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey) {
+    public String toString(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey, boolean includeDebugInfo) {
         StringBuilder builder = new StringBuilder();
-        builder.append(super.toString(includeLookahead, includePrivateKeys, aesKey));
+        builder.append(super.toString(includeLookahead, includePrivateKeys, aesKey, includeDebugInfo));
         builder.append("\n").append("Authentication Key Usage").append("\n");
         NetworkParameters params;
         if (wallet != null)

--- a/core/src/test/java/org/bitcoinj/wallet/LargeCoinJoinWalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/LargeCoinJoinWalletTest.java
@@ -103,8 +103,12 @@ public class LargeCoinJoinWalletTest {
         info("wallet.coinjoin.toString: {}", watch2);
 
         Stopwatch watch3 = Stopwatch.createStarted();
-        wallet.coinjoin.toString(true, false, null);
-        info("wallet.coinjoin.toString(true, false, null): {}", watch3);
+        wallet.coinjoin.toString(true, false, null, true);
+        info("wallet.coinjoin.toString(true, false, null, true): {}", watch3);
+
+        Stopwatch watch4 = Stopwatch.createStarted();
+        wallet.coinjoin.toString(true, false, null, false);
+        info("wallet.coinjoin.toString(true, false, null, false): {}", watch4);
     }
 
     @Test

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -1615,13 +1615,13 @@ public class WalletTool {
                 final KeyParameter aesKey = passwordToKey(true);
                 if (aesKey == null)
                     return; // Error message already printed.
-                System.out.println(wallet.toString(dumpLookahead, true, aesKey, true, true, chain));
+                System.out.println(wallet.toString(dumpLookahead, true, aesKey, true, true, chain, true));
             } else {
                 System.err.println("Can't dump privkeys, wallet is encrypted.");
                 return;
             }
         } else {
-            System.out.println(wallet.toString(dumpLookahead, dumpPrivkeys, null, true, true, chain));
+            System.out.println(wallet.toString(dumpLookahead, dumpPrivkeys, null, true, true, chain, true));
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. Shorten wallet toString output (unless debug info is to be included)

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Wallet.toString overloads are differnet.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to include or exclude detailed debug information in the wallet's string representations and related outputs.

- **Tests**
  - Updated tests to verify wallet string output with and without debug information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->