### PR TITLE
Fix/send delays

### DIFF
--- a/core/src/main/java/org/bitcoinj/quorums/InstantSendManager.java
+++ b/core/src/main/java/org/bitcoinj/quorums/InstantSendManager.java
@@ -163,7 +163,11 @@ public class InstantSendManager implements RecoveredSignatureListener {
     }
 
     public boolean isInstantSendEnabled() {
-        return sporkManager.isSporkActive(SporkId.SPORK_2_INSTANTSEND_ENABLED);
+        if (sporkManager == null) {
+            return false;
+        } else {
+            return sporkManager.isSporkActive(SporkId.SPORK_2_INSTANTSEND_ENABLED);
+        }
     }
 
     public void processInstantSendLock(Peer peer, InstantSendLock isLock) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletEx.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletEx.java
@@ -469,7 +469,7 @@ public class WalletEx extends Wallet {
         anonymizableTallyCached = false;
     }
     @VisibleForTesting
-    void clearCachesForTests() {
+    public void clearAllCaches() {
         clearAnonymizableCaches();
         mapOutpointRoundsCache.clear();
     }
@@ -1047,5 +1047,11 @@ public class WalletEx extends Wallet {
             }
         }
         return txs;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        clearAllCaches();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow the Wallet.reset() function to wipe caches in WalletEx.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare crashes when InstantSend is unavailable or misconfigured.
  * Improved wallet stability with stronger thread-safety for friend-related operations and transaction retrieval.
  * Avoids creating duplicate key chains and ensures consistent reads under concurrency.

* **Refactor**
  * Streamlined cache management; wallet resets now also clear relevant caches.
  * Minor public API adjustments related to cache clearing visibility to align with broader usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->