### PR TITLE
fix: avoid lazy RegTestParams construction in ZeroConfCoinSelector

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/ZeroConfCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/ZeroConfCoinSelector.java
@@ -14,9 +14,9 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
-import org.bitcoinj.params.RegTestParams;
 
 public class ZeroConfCoinSelector extends DefaultCoinSelector {
 
@@ -45,6 +45,9 @@ public class ZeroConfCoinSelector extends DefaultCoinSelector {
         return type.equals(TransactionConfidence.ConfidenceType.BUILDING) || type.equals(TransactionConfidence.ConfidenceType.PENDING) &&
                 // In regtest mode we expect to have only one peer, so we won't see transactions propagate.
                 // TODO: The value 1 below dates from a time when transactions we broadcast *to* were counted, set to 0
-                (confidence.numBroadcastPeers() > 1 || tx.getParams() == RegTestParams.get());
+                // Compare against the network id rather than RegTestParams.get(): the latter lazily constructs
+                // RegTestParams (recomputing and asserting the regtest genesis X11 hash), which can throw when first
+                // triggered on a contended background thread (e.g. CoinJoin) even on mainnet/testnet wallets.
+                (confidence.numBroadcastPeers() > 1 || NetworkParameters.ID_REGTEST.equals(tx.getParams().getId()));
     }
 }


### PR DESCRIPTION
## Problem

`ZeroConfCoinSelector.isTransactionSelectable()` compares a pending transaction's params against `RegTestParams.get()` for **every pending output** it evaluates:

```java
(confidence.numBroadcastPeers() > 1 || tx.getParams() == RegTestParams.get());
```

`RegTestParams.get()` lazily runs the `RegTestParams` constructor, which recomputes the regtest genesis **X11 hash** and `checkState()`s it against a hardcoded constant.

When that lazy construction is first triggered on a contended background thread — notably the wallet's CoinJoin IO coroutines, which do heavy concurrent X11 hashing — a transient bad X11 result makes the `checkState` throw `IllegalStateException`, crashing coin selection / balance calculation. This happens on **mainnet/testnet wallets that never use regtest**.

Observed crash (dash-wallet, CoinJoin balance update):

```
java.lang.IllegalStateException
  at com.google.common.base.Preconditions.checkState(Preconditions.java:486)
  at org.bitcoinj.params.RegTestParams.<init>(RegTestParams.java:46)
  at org.bitcoinj.params.RegTestParams.get(RegTestParams.java:138)
  at org.bitcoinj.wallet.ZeroConfCoinSelector.isTransactionSelectable(ZeroConfCoinSelector.java:48)
  at org.bitcoinj.wallet.ZeroConfCoinSelector.shouldSelect(ZeroConfCoinSelector.java:36)
  at org.bitcoinj.wallet.DefaultCoinSelector.select(DefaultCoinSelector.java:62)
  at org.bitcoinj.wallet.WalletEx.selectCoinsGroupedByAddresses(WalletEx.java:502)
  at org.bitcoinj.wallet.WalletEx.getAnonymizableBalance(WalletEx.java:672)
```

The hardcoded regtest genesis constant is correct — verified that `RegTestParams.get()` succeeds under a correct X11 — so the failures are transient corruption of the X11 computation, not a stale constant.

## Fix

Compare against `NetworkParameters.ID_REGTEST` (a plain field lookup) instead of constructing `RegTestParams`. Behavior is unchanged: `RegTestParams` sets `id = ID_REGTEST`, so the regtest special-case still applies — it just no longer recomputes/asserts the genesis hash on a hot, concurrent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed handling of zero-confirmation transactions in regression test mode, ensuring transactions are correctly identified and eligible for coin selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->